### PR TITLE
feat: add ambient styling and dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,22 +16,25 @@
     }
     *{box-sizing:border-box}
     html{scroll-behavior:smooth}
-    html,body{margin:0;padding:0;background:var(--bg);color:var(--text);font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,"Helvetica Neue",Arial,sans-serif;}
+    html,body{margin:0;padding:0;background:linear-gradient(180deg,var(--bg),var(--bg-soft));color:var(--text);font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,"Helvetica Neue",Arial,sans-serif;line-height:1.5;transition:background-color .3s,color .3s}
+    body{animation:fadein .6s ease-out}
     body.rtl{direction:rtl;font-family:"Noto Nastaliq Urdu", serif;}
-    a{color:var(--brand);text-decoration:none}
+    @keyframes fadein{from{opacity:0}to{opacity:1}}
+    a{color:var(--brand);text-decoration:none;transition:color .3s,background-color .3s}
+    a:focus-visible,.btn:focus-visible{outline:3px solid var(--accent);outline-offset:2px}
     img{max-width:100%;display:block}
     .container{width:min(1100px,92%);margin-inline:auto}
-    .btn{display:inline-flex;align-items:center;justify-content:center;gap:.5rem;background:var(--brand);color:#fff;padding:.9rem 1rem;border-radius:12px;border:0;cursor:pointer;font-weight:700;box-shadow:var(--shadow);min-height:44px;min-width:44px}
-    .btn.secondary{background:#fff;color:var(--brand);border:2px solid var(--brand)}
+    .btn{display:inline-flex;align-items:center;justify-content:center;gap:.5rem;background:var(--brand);color:#fff;padding:.9rem 1rem;border-radius:12px;border:0;cursor:pointer;font-weight:700;box-shadow:var(--shadow);min-height:44px;min-width:44px;transition:background-color .3s,color .3s,box-shadow .3s}
+    .btn.secondary{background:var(--bg);color:var(--brand);border:2px solid var(--brand)}
     .btn.light{background:#e8fff6;color:var(--brand)}
     .tag{display:inline-block;padding:.35rem .7rem;border-radius:999px;background:#e8fff6;color:var(--brand);font-weight:700;font-size:.85rem}
 
-    header.site{position:sticky;top:0;z-index:30;background:#ffffffcc;backdrop-filter:saturate(180%) blur(10px);border-bottom:1px solid #eef2f7}
+    header.site{position:sticky;top:0;z-index:30;background:#ffffffcc;backdrop-filter:saturate(180%) blur(10px);border-bottom:1px solid #eef2f7;transition:background-color .3s,border-color .3s}
     .nav{display:flex;align-items:center;justify-content:space-between;padding:.7rem 0}
     .brand-wrap{display:flex;align-items:center;gap:.5rem}
     .brand-title{font-weight:800;letter-spacing:.2px}
     .links{display:flex;align-items:center;gap:.25rem;flex-wrap:wrap}
-    .nav a.link{padding:.6rem .75rem;border-radius:10px;color:var(--text)}
+    .nav a.link{padding:.6rem .75rem;border-radius:10px;color:var(--text);transition:background-color .3s,color .3s}
     .nav a.link:hover{background:var(--bg-soft)}
     .actions{display:flex;gap:.5rem;align-items:center}
 
@@ -44,7 +47,7 @@
     .hero{padding:1.5rem 0 1.25rem;display:grid;grid-template-columns:1.1fr .9fr;gap:1.25rem;align-items:start}
     .hero h1{font-size:clamp(1.6rem,4vw,2.6rem);line-height:1.15;margin:.2rem 0}
     .hero p{color:var(--muted);font-size:clamp(.95rem,1.8vw,1.05rem)}
-    .card{background:#fff;border:1px solid #eef2f7;border-radius:var(--radius);box-shadow:var(--shadow)}
+    .card{background:var(--bg);border:1px solid #eef2f7;border-radius:var(--radius);box-shadow:var(--shadow);transition:background-color .3s,border-color .3s}
     .card.pad{padding:1rem}
 
     .grid-3{display:grid;grid-template-columns:repeat(3,1fr);gap:1rem}
@@ -87,6 +90,17 @@
     /* Maps placeholder iframe responsive */
     .map{position:relative;padding-bottom:56%;height:0;overflow:hidden;border-radius:12px;border:1px solid #e5e7eb}
     .map iframe{position:absolute;top:0;left:0;width:100%;height:100%;border:0}
+
+    @media (prefers-color-scheme: dark){
+      :root{
+        --text:#f1f5f9;--muted:#94a3b8;
+        --bg:#0f172a;--bg-soft:#1e293b;
+        --brand:#34d399;--brand-2:#047857;--accent:#fbbf24;
+      }
+      header.site{background:#0f172acc;border-bottom:1px solid #1e293b}
+      .card{background:var(--bg-soft);border-color:#334155}
+      .btn.secondary{background:var(--bg)}
+    }
 
     /* ======== Mobile tweaks ======== */
     @media(max-width:900px){


### PR DESCRIPTION
## Summary
- add gradient background, fade-in animation, and focus/transition styles for a more ambient feel
- support automatic dark mode via prefers-color-scheme variables and component tweaks

## Testing
- `npx --yes htmlhint index.html`
- `npx --yes prettier index.html --check` *(warns about existing code style)*

------
https://chatgpt.com/codex/tasks/task_e_68955d5993b08328854ae170643f9c20